### PR TITLE
Add annotations to fix availability warnings

### DIFF
--- a/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
@@ -20,6 +20,7 @@ public protocol DTPhotoViewerBaseAnimator: UIViewControllerAnimatedTransitioning
     var usesSpringAnimation: Bool { get set }
 }
 
+@available(iOS 10, *)
 public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
     
     /// Preseting transition duration

--- a/DTPhotoViewerController/Classes/DTPhotoViewerController+UISrcrollViewDelegate.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoViewerController+UISrcrollViewDelegate.swift
@@ -9,6 +9,7 @@
 import UIKit
 
 //MARK: - UICollectionViewDelegateFlowLayout
+@available(iOS 10, *)
 extension DTPhotoViewerController: UICollectionViewDelegateFlowLayout {
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         delegate?.photoViewerController?(self, scrollViewDidScroll: scrollView)

--- a/DTPhotoViewerController/Classes/DTPhotoViewerController.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoViewerController.swift
@@ -12,6 +12,7 @@ import Photos
 
 private let kPhotoCollectionViewCellIdentifier = "Cell"
 
+@available(iOS 10, *)
 open class DTPhotoViewerController: UIViewController {
     /// Scroll direction
     /// Default value is UICollectionViewScrollDirectionVertical
@@ -586,6 +587,7 @@ open class DTPhotoViewerController: UIViewController {
 }
 
 //MARK: - UIViewControllerTransitioningDelegate
+@available(iOS 10, *)
 extension DTPhotoViewerController: UIViewControllerTransitioningDelegate {
     public func animationController(forPresented presented: UIViewController, presenting: UIViewController, source: UIViewController) -> UIViewControllerAnimatedTransitioning? {
         return animator
@@ -597,6 +599,7 @@ extension DTPhotoViewerController: UIViewControllerTransitioningDelegate {
 }
 
 //MARK: UICollectionViewDataSource
+@available(iOS 10, *)
 extension DTPhotoViewerController: UICollectionViewDataSource {
     //MARK: Public methods
     public var currentPhotoIndex: Int {
@@ -651,6 +654,7 @@ extension DTPhotoViewerController: UICollectionViewDataSource {
 }
 
 //MARK: Open methods
+@available(iOS 10, *)
 extension DTPhotoViewerController {
     // For each reuse identifier that the collection view will use, register either a class or a nib from which to instantiate a cell.
     // If a nib is registered, it must contain exactly 1 top level object which is a DTPhotoCollectionViewCell.
@@ -732,6 +736,7 @@ extension DTPhotoViewerController {
 }
 
 //MARK: DTPhotoCollectionViewCellDelegate
+@available(iOS 10, *)
 extension DTPhotoViewerController: DTPhotoCollectionViewCellDelegate {
     open func collectionViewCellDidZoomOnPhoto(_ cell: DTPhotoCollectionViewCell, atScale scale: CGFloat) {
         if let indexPath = collectionView.indexPath(for: cell) {

--- a/DTPhotoViewerController/Classes/DTPhotoViewerControllerDataSource.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoViewerControllerDataSource.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 10, *)
 @objc public protocol DTPhotoViewerControllerDataSource: NSObjectProtocol {
     /// Total number of photo in viewer.
     func numberOfItems(in photoViewerController: DTPhotoViewerController) -> Int

--- a/DTPhotoViewerController/Classes/DTPhotoViewerControllerDelegate.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoViewerControllerDelegate.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@available(iOS 10, *)
 @objc public protocol DTPhotoViewerControllerDelegate: NSObjectProtocol {
     @objc optional func photoViewerController(_ photoViewerController: DTPhotoViewerController, didScrollToPhotoAt index: Int)
     


### PR DESCRIPTION
When integrating `DTPhotoViewerConroller` into a project using Swift Package Manager and Xcode 11 you get warnings about `UIViewPropertyAnimator` only being available in iOS 10+. Adding availability annotations fixes those errors and allows you to build the project.