### PR TITLE
Open `DTPhotoAnimator` class for subclassing

### DIFF
--- a/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
@@ -20,7 +20,7 @@ public protocol DTPhotoViewerBaseAnimator: UIViewControllerAnimatedTransitioning
     var usesSpringAnimation: Bool { get set }
 }
 
-public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
+open class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
     
     /// Preseting transition duration
     /// Default value is 0.4


### PR DESCRIPTION
At [Luma](https://lu.ma/) we're building a mobile app where users will be able to view images sent in chat using `DTPhotoViewerController`.

To make conversation view look nice we put a bubble-like mask on top of image (iMessage-style).

We want to animate mask of `photoViewerController.imageView` as it is transitioning from "open" to `referencedView` position.

In order to do that (add additional animation to existing `DTPhotoAnimator` animation) right now we need to use decorator pattern over `DTPhotoAnimator` — create a complete class conforming to `DTPhotoViewerBaseAnimator` and inside proxy all the calls/variables to an instance of `DTPhotoAnimator`.

It would be significantly easier and require less code if `DTPhotoAnimator` was a class open to subclassing — we'd only need to override one method.