### PR TITLE
Split dismissal animations into spring and linear-based ones

### DIFF
--- a/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoAnimator.swift
@@ -55,6 +55,7 @@ public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
         toViewController.beginAppearanceTransition(true, animated: transitionContext.isAnimated)
         
         let animator: UIViewPropertyAnimator
+        var linearAnimator: UIViewPropertyAnimator?
         
         if isPresenting {
             guard let photoViewerController = toViewController as? DTPhotoViewerController else {
@@ -129,7 +130,7 @@ public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
             photoViewerController.imageView.backgroundColor = .clear
             
             let animation = {
-                photoViewerController.dismissingAnimation()
+                photoViewerController.dismissingSpringAnimation()
                 
                 if let referencedView = photoViewerController.referencedView {
                     photoViewerController.imageView.layer.cornerRadius = referencedView.layer.cornerRadius
@@ -139,9 +140,15 @@ public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
             
             if usesSpringAnimation {
                 animator = UIViewPropertyAnimator(duration: duration, dampingRatio: kDampingRatio, animations: animation)
+                linearAnimator = UIViewPropertyAnimator(duration: duration / 4, curve: .easeOut, animations: {
+                    photoViewerController.dismissingLinearAnimation()
+                })
             }
             else {
                 animator = UIViewPropertyAnimator(duration: duration, curve: .linear, animations: animation)
+                linearAnimator = UIViewPropertyAnimator(duration: duration, curve: .linear, animations: {
+                    photoViewerController.dismissingLinearAnimation()
+                })
             }
             
             animator.addCompletion { _ in
@@ -182,6 +189,7 @@ public class DTPhotoAnimator: NSObject, DTPhotoViewerBaseAnimator {
         }
         
         animator.startAnimation()
+        linearAnimator?.startAnimation()
     }
     
     public func animationEnded(_ transitionCompleted: Bool) {

--- a/DTPhotoViewerController/Classes/DTPhotoViewerController.swift
+++ b/DTPhotoViewerController/Classes/DTPhotoViewerController.swift
@@ -256,7 +256,8 @@ open class DTPhotoViewerController: UIViewController {
         super.viewWillDisappear(animated)
         
         if !animated {
-            dismissingAnimation()
+            dismissingSpringAnimation()
+            dismissingLinearAnimation()
             dismissalAnimationDidFinish()
         }
         else {
@@ -524,9 +525,13 @@ open class DTPhotoViewerController: UIViewController {
         setNeedsStatusBarAppearanceUpdate()
     }
     
-    func dismissingAnimation() {
-        imageView.frame = frameForReferencedView()
+    func dismissingSpringAnimation() {
+        imageView.frame.origin = frameForReferencedView().origin
         backgroundView.alpha = 0
+    }
+
+    func dismissingLinearAnimation() {
+        imageView.frame.size = frameForReferencedView().size
     }
     
     func presentationAnimationDidFinish() {


### PR DESCRIPTION
This allows us to animate `frame.origin` with a spring and `frame.size` linearly so that applying a mask which can't overshoot doesn't look strange, as if only one corner was rounded.

![Untitled-2021-09-09-2136-4](https://user-images.githubusercontent.com/1151041/132870282-274436af-d48e-44d8-a844-69c7ad9a04cc.png)
